### PR TITLE
Fix cardinality failure on scalable bloom fitler

### DIFF
--- a/larkspur/larkspur.py
+++ b/larkspur/larkspur.py
@@ -392,7 +392,7 @@ class ScalableBloomFilter:
                 return True
         return False
 
-    def add(self, key: Union[bytes, str]) -> bool:
+    def add(self, key: KeyType) -> bool:
         """Adds the item key into the bloom filter.
 
         Args:

--- a/larkspur/larkspur.py
+++ b/larkspur/larkspur.py
@@ -1,6 +1,7 @@
 import math
 import hashlib
 from struct import pack, unpack
+from typing import Union
 
 
 def deserialize_hm(hm):
@@ -285,7 +286,22 @@ class ScalableBloomFilter:
                 return True
         return False
 
-    def add(self, key):
+    def add(self, key: Union[bytes, str]) -> bool:
+        """Adds the item key into the bloom filter.
+
+        Args:
+            key: The item to be added.
+
+        Returns:
+            True if key exists and False if it not and it was added
+        """
+        # Check to see if any filters already contain the key.
+        # This check is necessary because self._get_next_filter will return the latest 
+        # BloomFilter which may not contain this key, but the key may still exist
+        # in an earlier BloomFilter if initial_capacity was exceeded.
+        if self.__contains__(key):
+            return True
+
         bf = self._get_next_filter()
         return bf.add(key)
 

--- a/larkspur/larkspur.py
+++ b/larkspur/larkspur.py
@@ -405,7 +405,7 @@ class ScalableBloomFilter:
         # This check is necessary because self._get_next_filter will return the latest 
         # BloomFilter which may not contain this key, but the key may still exist
         # in an earlier BloomFilter if initial_capacity was exceeded.
-        if self.__contains__(key):
+        if key in self:
             return True
 
         bf = self._get_next_filter()

--- a/larkspur/test_larkspur.py
+++ b/larkspur/test_larkspur.py
@@ -118,3 +118,11 @@ class TestScalableBloomFilter(LarkspurTestCase):
             assert self.r.ttl(bf.meta_name) == 60
         assert self.r.ttl(sbf.name) == 60
         assert self.r.ttl(sbf.meta_name) == 60
+
+    def test_cardinality(self):
+        sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1)
+        member = str(ObjectId())
+        # Create a new key
+        assert not sbf.add(member)
+        # Try to create the same key again
+        assert sbf.add(member)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "larkspur"
-version = "0.2.2"
+version = "0.2.3"
 description = "a Redis-backed, scalable Bloom filter"
 authors = ["Thomas R Storey <orey.st@protonmail.com>"]
 


### PR DESCRIPTION
Currently, when the initial_size is exceed on a scalable bloom filter, new objects being added are recounted as unique. This remedies that issue by checking the previous BloomFilters for a key before attempting to add them to the most recent BloomFilter.

A ScalableBloomFilter is best thought of as a list BloomFilters. The ScalableBloomFilter scales when the latest BloomFilter becomes full. It scales by creating another BloomFilter with a larger initial size than the previous BloomFilter, i.e. `initial_size * scale`. The default scale is 4, so assuming you have a ScalableBloomFilter with an initial size of 1 and add a single object to it, your ScalableBloomFilter would then exhibit the following structure:

```
ScalableBloomFilter:
    BloomFilter1:
        initial_size: 1
    BloomFilter2:
        initial_size: 4
```

The issue is that, when an item that exists in BloomFilter1 was added to the ScalableBloomFilter, it would previously only check cardinality against BloomFilter2. This caused the item to be added again as unique, inflating the cardinality count.