### PR TITLE
fix: sorting of BloomFilters

### DIFF
--- a/larkspur/larkspur.py
+++ b/larkspur/larkspur.py
@@ -327,7 +327,11 @@ class ScalableBloomFilter:
         self.initial_capacity = meta.get('initial_capacity') or initial_capacity
         if not self.connection.exists(self.meta_name):
             self._create_meta()
-        filter_names = sorted(list(self.connection.smembers(self.name)))
+        filter_names = list(self.connection.smembers(self.name))
+        # Sort the bloomfilters according to their bf# as they are in format NAME:bf0
+        filter_names.sort(
+            key=lambda bf_name: int(bf_name.decode("utf-8").split(":")[-1][2:])
+        )
         self.filters = [
             BloomFilter(connection, fn.decode('utf8'), self.initial_capacity)
             for fn in filter_names

--- a/larkspur/test_larkspur.py
+++ b/larkspur/test_larkspur.py
@@ -15,8 +15,8 @@ class TestBloomFilter(LarkspurTestCase):
 
     def test_add(self):
         bf = BloomFilter(self.r, 'test', capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(1000)]
-        nonmembers = [str(ObjectId()) for x in range(10)]
+        members = [str(ObjectId()) for _ in range(1000)]
+        nonmembers = [str(ObjectId()) for _ in range(10)]
         for oid in members:
             bf.add(oid)
         margin = 0.002 * 1000
@@ -37,8 +37,8 @@ class TestBloomFilter(LarkspurTestCase):
 
     def test_bulk_add(self):
         bf = BloomFilter(self.r, 'test', capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(1000)]
-        nonmembers = [str(ObjectId()) for x in range(10)]
+        members = [str(ObjectId()) for _ in range(1000)]
+        nonmembers = [str(ObjectId()) for _ in range(10)]
         bf.bulk_add(members)
         margin = 0.002 * 1000
         assert(all([oid in bf for oid in members]))
@@ -49,7 +49,7 @@ class TestBloomFilter(LarkspurTestCase):
 
     def test_flush(self):
         bf = BloomFilter(self.r, 'test', capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(1000)]
+        members = [str(ObjectId()) for _ in range(1000)]
         bf.bulk_add(members)
         assert bf.count >= 990
         bf.flush(None)
@@ -60,8 +60,8 @@ class TestBloomFilter(LarkspurTestCase):
 class TestScalableBloomFilter(LarkspurTestCase):
     def test_add(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(6000)]
-        nonmembers = [str(ObjectId()) for x in range(10)]
+        members = [str(ObjectId()) for _ in range(6000)]
+        nonmembers = [str(ObjectId()) for _ in range(10)]
         for oid in members:
             sbf.add(oid)
         margin = 0.002 * 6000
@@ -73,8 +73,8 @@ class TestScalableBloomFilter(LarkspurTestCase):
 
     def test_bulk_add(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(6000)]
-        nonmembers = [str(ObjectId()) for x in range(10)]
+        members = [str(ObjectId()) for _ in range(6000)]
+        nonmembers = [str(ObjectId()) for _ in range(10)]
         sbf.bulk_add(members)
         margin = 0.002 * 6000
         assert(all([oid in sbf for oid in members]))
@@ -85,14 +85,14 @@ class TestScalableBloomFilter(LarkspurTestCase):
 
     def test_count(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(10000)]
+        members = [str(ObjectId()) for _ in range(10000)]
         for oid in members:
             sbf.add(oid)
         assert sbf.count >= 9980
 
     def test_clear(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(6000)]
+        members = [str(ObjectId()) for _ in range(6000)]
         sbf.bulk_add(members)
         assert sbf.count >= 5988
         sbf.flush()
@@ -101,7 +101,7 @@ class TestScalableBloomFilter(LarkspurTestCase):
 
     def test_existing_filter(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(3000)]
+        members = [str(ObjectId()) for _ in range(3000)]
         sbf.bulk_add(members)
         sbf2 = ScalableBloomFilter(self.r, 'test')
         assert sbf2.count == sbf.count
@@ -110,7 +110,7 @@ class TestScalableBloomFilter(LarkspurTestCase):
 
     def test_expire(self):
         sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1000, error_rate=0.001)
-        members = [str(ObjectId()) for x in range(3000)]
+        members = [str(ObjectId()) for _ in range(3000)]
         sbf.bulk_add(members)
         sbf.expire(60)
         for bf in sbf.filters:
@@ -126,3 +126,11 @@ class TestScalableBloomFilter(LarkspurTestCase):
         assert not sbf.add(member)
         # Try to create the same key again
         assert sbf.add(member)
+
+    def test_sort(self):
+        sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1, scale=1)
+        # Create a keys until we have double digit BloomFilters
+        [sbf.add(str(ObjectId())) for _ in range(0, 11)]
+        # Reload and nsure the last filter is filter 10
+        sbf = ScalableBloomFilter(self.r, 'test', initial_capacity=1, scale=1)
+        assert sbf.filters[-1].meta_name == "bfmeta:test:bf10"


### PR DESCRIPTION
ScalableBloomFilters were relying on the sorted to sort their BloomFilters by name. An issue arises when the BloomFilters reach a certain capacity threshold 256,000 clicks or 512,000 persons in that a 10th BloomFilter is created within the ScalableBloomFilter. 
Sorted would sort them as
```
NAME:bf0
NAME:bf1
NAME:bf10
NAME:bf2
NAME:bf3
NAME:bf4
NAME:bf5
NAME:bf6
NAME:bf7
NAME:bf8
NAME:bf9
```
Which causes the capacity calculations to continuously use the 9th bloom filter rather than the 10th for scaling. This causes the ScalableBloomFilter to continue creating BloomFilters of too small a size, ultimately leading to the creation of 1,000s, making the ScalableBloomFilter stop loading. This fixes the sort so it is sorted numerically by bf:#